### PR TITLE
做了部分修改，可以在MariaDB上运行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ target/
 .settings/
 log/
 target/
+.idea/
+project.iml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="9" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/classes" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/init.sql
+++ b/init.sql
@@ -563,6 +563,8 @@ INSERT INTO `t_user` VALUES ('125', '卑微的浮萍', 'c1cc7ea10ee9b41fd33f1293
 INSERT INTO `t_user` VALUES ('161', 'hero', '1ab36105101bab2e665eeeb954ee4aa2', '4', 'hero@qq.com', '13477589012', '0', '2018-02-05 14:54:25', '2018-02-27 14:57:20', null, '0', 'green', 'default.jpg', null);
 INSERT INTO `t_user` VALUES ('162', 'beibei', 'b5ce06e87e255d097fb6956f7fb0d8b3', '5', 'beibei@qq.com', '13488873263', '1', '2018-02-24 17:34:14', '2018-03-01 16:11:43', '2018-03-14 11:41:39', '2', 'green', '17e420c250804efe904a09a33796d5a10.jpg', '我是贝贝。');
 
+--INSERT INTO `t_user` VALUES ('1', 'brown', 'brown', '5', 'brown@qq.com', '13488873263', '1', '2018-02-24 17:34:14', '2018-03-01 16:11:43', '2018-03-14 11:41:39', '2', 'green', '17e420c250804efe904a09a33796d5a10.jpg', '我是brown');
+
 -- ----------------------------
 -- Table structure for t_user_role
 -- ----------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 		    <groupId>org.springframework.boot</groupId>
 		    <artifactId>spring-boot-starter-tomcat</artifactId>
-		    <scope>provided</scope>
+		    <scope>compile</scope>
 		</dependency>
 		
 		<dependency>

--- a/problems.md
+++ b/problems.md
@@ -1,0 +1,15 @@
+数据库名字: mrbird
+需要设置数据库的字符编码为utf8,而不是utf8mb4，具体设置方式可以参考下面几个文档
+
+https://blog.csdn.net/qiyuexuelang/article/details/9049985
+https://scottlinux.com/2017/03/04/mysql-mariadb-set-character-set-and-collation-to-utf8/
+https://stackoverflow.com/questions/22572558/how-to-set-character-set-database-and-collation-database-to-utf8-in-my-ini?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
+
+只有设置完编码后才能建立数据库，若一开始建立了数据库，character_set_database 的编码不会变。
+
+用$ mysql -u root -p  -D mrbird < init.sql 初始化数据库。
+
+linux使用1024以下的端口需要root权限，所以可以在配置文件中将端口改为8080。
+https://blog.csdn.net/ycpanda/article/details/12201851
+
+开发时直接使用Spring Boot的入口类启动即可，访问地址localhost。部署时建议打包成war包，访问地址localhost:(端口号)/febs。账号mrbird，密码123456。

--- a/src/main/java/cc/mrbird/system/domain/Dept.java
+++ b/src/main/java/cc/mrbird/system/domain/Dept.java
@@ -10,7 +10,7 @@ import javax.persistence.Table;
 
 import cc.mrbird.common.annotation.ExportConfig;
 
-@Table(name = "T_DEPT")
+@Table(name = "t_dept")
 public class Dept implements Serializable {
 
 	private static final long serialVersionUID = -7790334862410409053L;

--- a/src/main/java/cc/mrbird/system/domain/Dict.java
+++ b/src/main/java/cc/mrbird/system/domain/Dict.java
@@ -9,7 +9,7 @@ import javax.persistence.Table;
 
 import cc.mrbird.common.annotation.ExportConfig;
 
-@Table(name = "T_DICT")
+@Table(name = "t_dict")
 public class Dict implements Serializable{
 
 	private static final long serialVersionUID = 7780820231535870010L;

--- a/src/main/java/cc/mrbird/system/domain/Menu.java
+++ b/src/main/java/cc/mrbird/system/domain/Menu.java
@@ -10,7 +10,7 @@ import javax.persistence.Table;
 
 import cc.mrbird.common.annotation.ExportConfig;
 
-@Table(name = "T_MENU")
+@Table(name = "t_menu")
 public class Menu implements Serializable {
 
 	private static final long serialVersionUID = 7187628714679791771L;

--- a/src/main/java/cc/mrbird/system/domain/Role.java
+++ b/src/main/java/cc/mrbird/system/domain/Role.java
@@ -10,7 +10,7 @@ import javax.persistence.Table;
 
 import cc.mrbird.common.annotation.ExportConfig;
 
-@Table(name = "T_ROLE")
+@Table(name = "t_role")
 public class Role implements Serializable {
 
 	private static final long serialVersionUID = -1714476694755654924L;

--- a/src/main/java/cc/mrbird/system/domain/RoleMenu.java
+++ b/src/main/java/cc/mrbird/system/domain/RoleMenu.java
@@ -5,7 +5,7 @@ import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Table;
 
-@Table(name = "T_ROLE_MENU")
+@Table(name = "t_role_menu")
 public class RoleMenu implements Serializable {
 	
 	private static final long serialVersionUID = -7573904024872252113L;

--- a/src/main/java/cc/mrbird/system/domain/SysLog.java
+++ b/src/main/java/cc/mrbird/system/domain/SysLog.java
@@ -10,7 +10,7 @@ import javax.persistence.Table;
 
 import cc.mrbird.common.annotation.ExportConfig;
 
-@Table(name = "T_LOG")
+@Table(name = "t_log")
 public class SysLog implements Serializable {
 
 	private static final long serialVersionUID = -8878596941954995444L;

--- a/src/main/java/cc/mrbird/system/domain/User.java
+++ b/src/main/java/cc/mrbird/system/domain/User.java
@@ -11,7 +11,7 @@ import javax.persistence.Transient;
 
 import cc.mrbird.common.annotation.ExportConfig;
 
-@Table(name = "T_USER")
+@Table(name = "t_user")
 public class User implements Serializable {
 
 	private static final long serialVersionUID = -4852732617765810959L;

--- a/src/main/java/cc/mrbird/system/domain/UserRole.java
+++ b/src/main/java/cc/mrbird/system/domain/UserRole.java
@@ -5,7 +5,7 @@ import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Table;
 
-@Table(name = "T_USER_ROLE")
+@Table(name = "t_user_role")
 public class UserRole implements Serializable{
 	
 	private static final long serialVersionUID = -3166012934498268403L;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 80
+  port: 8080
   tomcat:
     uri-encoding: utf-8
     
@@ -9,9 +9,9 @@ spring:
       # 数据库访问配置, 使用druid数据源 
       type: com.alibaba.druid.pool.DruidDataSource
       driverClassName: com.mysql.jdbc.Driver
-      url: jdbc:mysql://127.0.0.1:3306/test?useUnicode=true&characterEncoding=utf8
+      url: jdbc:mysql://127.0.0.1:3306/mrbird?useUnicode=true&characterEncoding=utf8
       username: root
-      password: 123456   
+      password: 13579
       # 连接池配置
       initial-size: 5
       min-idle: 5


### PR DESCRIPTION
我在Arch LInux上运行了**MySQL分支**的代码，数据库：Ver 15.1 Distrib 10.1.31-MariaDB, for Linux (x86_64)，解决了数据库表名**大小写**的一些问题。由于LInux下使用1024以下端口需要root权限，我把配置文件中的默认端口改为**8080**。