### PR TITLE
开启 java 1.8 -parameters 参数， 可通过反射获取方法的原始参数名 非 以 args 开头

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,33 @@
                     </resources>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <compilerArgs>
+                        <!-- 开启此参数 可通过反射获取方法的原始参数名 非 以 args 开头 java1.8  有效,add  by jyao-->
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
         </plugins>
         <finalName>febs</finalName>
     </build>

--- a/src/main/java/cc/mrbird/common/aspect/LimitAspect.java
+++ b/src/main/java/cc/mrbird/common/aspect/LimitAspect.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  */
 @Aspect
 @Component
-public class LimitAspect{
+public class LimitAspect {
 
     private static final Logger logger = LoggerFactory.getLogger(LimitAspect.class);
 
@@ -85,6 +85,7 @@ public class LimitAspect{
     /**
      * 限流脚本
      * 调用的时候不超过阈值，则直接返回并执行计算器自加。
+     *
      * @return lua脚本
      */
     private String buildLuaScript() {

--- a/src/main/java/cc/mrbird/common/util/AddressUtils.java
+++ b/src/main/java/cc/mrbird/common/util/AddressUtils.java
@@ -46,7 +46,7 @@ public class AddressUtils {
 			reader.close();
 			return buffer.toString();
 		} catch (IOException e) {
-			e.printStackTrace();
+//			e.printStackTrace();
 		} finally {
 			if (connection != null) {
 				connection.disconnect();


### PR DESCRIPTION
开启 java 1.8 -parameters 参数， 可通过反射获取方法的原始参数名 非 以 args 开头

Signed-off-by: j.yao <jackyao713911@gmail.com>